### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through a stack trace

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -226,10 +226,9 @@ async function requestHandler(req, res) {
     res.end(JSON.stringify(fetchResult));
   } catch (err) {
     // Catch‑all error handler
+    console.error('Unhandled error in requestHandler:', err); // Log full error for diagnostics
     res.writeHead(500, { 'Content-Type': 'application/json' });
-    res.end(
-      JSON.stringify({ error: 'internal_server_error', detail: String(err?.message || err) })
-    );
+    res.end(JSON.stringify({ error: 'internal_server_error' }));
   }
 }
 
@@ -238,11 +237,10 @@ export function createServer() {
   return http.createServer((req, res) => {
     // Ensure the handler promise rejections are surfaced
     requestHandler(req, res).catch((err) => {
+        console.error('Unhandled error in request handler promise:', err); // Log error for diagnostics
       try {
         res.writeHead(500, { 'Content-Type': 'application/json' });
-        res.end(
-          JSON.stringify({ error: 'internal_server_error', detail: String(err?.message || err) })
-        );
+        res.end(JSON.stringify({ error: 'internal_server_error' }));
       } catch {}
     });
   });


### PR DESCRIPTION
Potential fix for [https://github.com/marco-jardim/chatgpt-proxy/security/code-scanning/2](https://github.com/marco-jardim/chatgpt-proxy/security/code-scanning/2)

To fix this issue, we should avoid exposing the contents of `err.message` or any error details to the client. In the catch block, instead of sending the potentially sensitive error information to the user, we should send only a generic error message such as `"internal_server_error"`. If detailed error information is needed for debugging, we should log the error to the server console or another logging facility. Changes need to be made in the `requestHandler` function (lines 227–233) where errors are caught and in the callback to `createServer()` (lines 240–247) where errors can also result in potentially unsafe exposure.  

The fix is as follows:
- In both locations (main catch block in `requestHandler` and fallback catch in `createServer`), replace the response error payload with a generic message, suppressing the inclusion of `err.message` and/or any stringified error.
- Log the `err` to the console (using `console.error`) so that developers still have access to the full stack and details for debugging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
