### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/marco-jardim/chatgpt-proxy/security/code-scanning/1](https://github.com/marco-jardim/chatgpt-proxy/security/code-scanning/1)

To resolve this issue, add an explicit `permissions:` block to restrict the GITHUB_TOKEN's permissions for the workflow. You can add the block either at the top-level of the workflow (before `jobs:`) to affect all jobs, or under individual jobs that require more specific permissions; here, a minimal block suffices at the workflow level. Since the workflow only checks out code and uploads to Codecov (using secrets for upload), it likely does not require write access to repository contents. Therefore, set `contents: read` at the root level of `.github/workflows/ci.yml`, directly below the `name:` (ideally before or after the `on:` block), as shown in the recommendation. No imports or additional dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
